### PR TITLE
Bugfix in oil-refinery.json

### DIFF
--- a/content/blocks/production/oil-refinery.json
+++ b/content/blocks/production/oil-refinery.json
@@ -16,9 +16,7 @@ outputLiquid: {
   liquid: liquid-gas
   amount: 0.1
 }
-outputItem: {
-  sulfur/1
-}
+outputItem: sulfur/1
 requirements: [
   titanium/80
   steel/60


### PR DESCRIPTION
When I went in to test 1.6, I got a runtime error about oil-refinery.json. I was able to fix it by deleting a couple of curly brackets.